### PR TITLE
[JAR-21] adding the ability to export gem analysis to JSON doc

### DIFF
--- a/lib/orion/cli/analyze.rb
+++ b/lib/orion/cli/analyze.rb
@@ -3,6 +3,7 @@
 require "thor"
 require_relative "../gems/parser"
 require_relative "../helpers/renderer"
+require "pastel"
 
 module Orion
   module CLI
@@ -21,9 +22,16 @@ module Orion
 
         analyzed_gems, vulnerabilities = analyzer.run
 
+        pastel = Pastel.new
+
         case options[:format]
         when "json"
-          puts JSON.pretty_generate(result)
+          path = analyzer.export_gem_report(analyzed_gems, vulnerabilities, include_vulns: options[:include_vulns])
+          puts pastel.green("✔  Gems Analyzed: ") + pastel.white("#{analyzed_gems.size}")
+          if options[:include_vulns]
+            puts pastel.red("✖  Vulnerabilities Found: ") + pastel.white("#{vulnerabilities.size}")
+          end
+          puts pastel.cyan("📄 Report Saved To: ") + pastel.yellow(path)
         else
           puts Orion::Helpers::Renderer.render_table(rows: analyzed_gems)
           puts "\nAnalyzed #{analyzed_gems.size} gems, Found #{vulnerabilities.size} vulnerabilities"

--- a/lib/orion/gems/parser.rb
+++ b/lib/orion/gems/parser.rb
@@ -1,9 +1,8 @@
 # frozen_string_literal: true
 
-# lib/orion/gems/parser.rb
-
 require "json"
 require "bundler"
+require "fileutils"
 require_relative "security"
 
 module Orion
@@ -32,6 +31,32 @@ module Orion
         end
 
         [analyzed_gems, vulnerabilities]
+      end
+
+      def gems_to_json(gems, vulns, include_vulns: false)
+        data = {
+          gems: gems,
+          total: {
+            gems: gems.size
+          }
+        }
+        if include_vulns
+          data[:vulnerabilities] = vulns
+          data[:total][:vulnerabilities] = vulns.size
+        end
+
+        JSON.pretty_generate(data)
+      end
+
+      def export_gem_report(gems, vulns, include_vulns: false, filename: "orion_gem_report.json")
+        dir = File.join(Dir.pwd, "orion-report")
+        FileUtils.mkdir_p(dir) unless Dir.exist?(dir)
+
+        data = gems_to_json(gems, vulns, include_vulns: include_vulns)
+        path = File.join(dir, filename)
+
+        File.write(path, data)
+        path
       end
     end
   end

--- a/lib/orion/version.rb
+++ b/lib/orion/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Orion
-  VERSION = "0.3.1"
+  VERSION = "0.4.1"
 end

--- a/orion.gemspec
+++ b/orion.gemspec
@@ -31,8 +31,8 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Abin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "bundler", ">= 2.0", "< 3.0"
-  spec.add_dependency "bundler-audit", ">= 0.9.0", "< 1.0"
+  spec.add_dependency "bundler", "~> 2.0"
+  spec.add_dependency "bundler-audit", "~> 0.9"
   spec.add_dependency "pastel", "~> 0.8"
   spec.add_dependency "thor", "~> 1.3.2"
   spec.add_dependency "tty-table", "~> 0.12"


### PR DESCRIPTION
## What
Giving users the ability to export analysis of their `Gemfile.lock` to a JSON doc under `orion/orion_gem_report.json`

## Why
This change is mainly intended for those who want to later reference their analysis or interact with it in a programmatic way.

## Where
Mainly working out of the `lib/gems` folder as well as a minor CLI tweak and associated testing `/test` 