### PR TITLE
[JAR-18] adding csv support for exporting gem vulnerabilities

### DIFF
--- a/lib/orion/cli/analyze.rb
+++ b/lib/orion/cli/analyze.rb
@@ -10,7 +10,7 @@ module Orion
     class Analyze < Thor
       desc "gems", "Analyze gem dependencies"
       option :lockfile, type: :string, default: "Gemfile.lock", aliases: "-l", desc: "Path relative to your cwd for the Gemfile.lock to be parsed"
-      option :format, type: :string, default: "table", enum: %w[table json], aliases: "-f", desc: "Specific formatting for results, default is table"
+      option :format, type: :string, default: "table", enum: %w[table json csv], aliases: "-f", desc: "Specific formatting for results, default is table"
       option :include_dev, type: :boolean, default: false, aliases: "-d", desc: "Include development and test gems"
       option :include_vulns, type: :boolean, default: false, aliases: "-v", desc: "Show vulnerable gems, formatted into a separate table"
 
@@ -25,14 +25,7 @@ module Orion
         pastel = Pastel.new
 
         case options[:format]
-        when "json"
-          path = analyzer.export_gem_report(analyzed_gems, vulnerabilities, include_vulns: options[:include_vulns])
-          puts pastel.green("✔  Gems Analyzed: ") + pastel.white("#{analyzed_gems.size}")
-          if options[:include_vulns]
-            puts pastel.red("✖  Vulnerabilities Found: ") + pastel.white("#{vulnerabilities.size}")
-          end
-          puts pastel.cyan("📄 Report Saved To: ") + pastel.yellow(path)
-        else
+        when "table"
           puts Orion::Helpers::Renderer.render_table(rows: analyzed_gems)
           puts "\nAnalyzed #{analyzed_gems.size} gems, Found #{vulnerabilities.size} vulnerabilities"
 
@@ -40,6 +33,18 @@ module Orion
             puts "\nVulnerabilities Found:"
             Orion::Helpers::Renderer.render_list(rows: vulnerabilities)
           end
+        else
+          path = analyzer.export_gem_report(
+            analyzed_gems,
+            vulnerabilities,
+            include_vulns: options[:include_vulns],
+            type: options[:format]
+          )
+          puts pastel.green("✔  Gems Analyzed: ") + pastel.white(analyzed_gems.size.to_s)
+          if options[:include_vulns]
+            puts pastel.red("✖  Vulnerabilities Found: ") + pastel.white(vulnerabilities.size.to_s)
+          end
+          puts pastel.cyan("📄 Report Saved To: ") + pastel.yellow(path)
         end
       end
     end

--- a/lib/orion/version.rb
+++ b/lib/orion/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Orion
-  VERSION = "0.4.1"
+  VERSION = "0.5.1"
 end

--- a/orion.gemspec
+++ b/orion.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "bundler", "~> 2.0"
   spec.add_dependency "bundler-audit", "~> 0.9"
+  spec.add_dependency "csv", "~> 3.0"
   spec.add_dependency "pastel", "~> 0.8"
   spec.add_dependency "thor", "~> 1.3.2"
   spec.add_dependency "tty-table", "~> 0.12"

--- a/test/cli/test_analyze.rb
+++ b/test/cli/test_analyze.rb
@@ -59,6 +59,21 @@ class AnalyzeCLITest < Minitest::Test
     end
   end
 
+  def test_gems_command_with_csv_option
+    Orion::Gems::Parser.stub :new, ->(**_) { StubbedParser.new(*@mock_data[0]) } do
+      FileUtils.stub :mkdir_p, nil do
+        File.stub :write, "mocked/path/orion_gem_report.csv" do
+          captured = capture_stdout do
+            Orion::CLI::Analyze.start(%w[gems --format csv --include-vulns])
+          end
+
+          assert_match(/orion_gem_report\.csv/, captured)
+          assert_match(/Report Saved To:/, captured)
+        end
+      end
+    end
+  end
+
   class StubbedParser
     def initialize(analyed_gems, vulnerabilities)
       @analyzed_gems = analyed_gems
@@ -69,25 +84,50 @@ class AnalyzeCLITest < Minitest::Test
       [@analyzed_gems, @vulnerabilities]
     end
 
-    def export_gem_report(gems, vulns, include_vulns: false, filename: "orion_gem_report.json")
+    def export_gem_report(gems, vulns, include_vulns: false, filename: "orion_gem_report", type: "json")
       dir = File.join(Dir.pwd, "orion-report")
       FileUtils.mkdir_p(dir) unless Dir.exist?(dir)
 
-      data = {
-        analyzed_gems: gems,
-        total: {
-          gems: gems.size
-        }
-      }
+      extension = type == "csv" ? "csv" : "json"
+      file_path = File.join(dir, "#{filename}.#{extension}")
 
-      if include_vulns
-        data[:vulnerabilities] = vulns
-        data[:total][:vulnerabilities] = vulns.size
-      end
+      output_data =
+        case type
+        when "json"
+          JSON.pretty_generate({
+            gems: gems,
+            total: { gems: gems.size }.tap do |total|
+              total[:vulnerabilities] = vulns.size if include_vulns
+            end,
+            vulnerabilities: (include_vulns ? vulns : nil)
+          }.compact)
+        when "csv"
+          CSV.generate(headers: true) do |csv|
+            csv << [
+              "Gem", "Version", "Source", "Secure",
+              "Advisories", "CVEs", "URLs", "Patched Versions"
+            ]
 
-      path = File.join(dir, filename)
-      File.write(path, JSON.pretty_generate(data))
-      path
+            gems.each do |gem|
+              gem_vulns = vulns.select { |v| v[:name] == gem[:name] }
+
+              advisories = gem_vulns.map { |v| v[:advisory] }.join(" | ")
+              cves = gem_vulns.map { |v| v[:cve] }.compact.join(" | ")
+              urls = gem_vulns.map { |v| v[:url] }.compact.join(" | ")
+              patched = gem_vulns.flat_map { |v| v[:patched_versions] }.uniq.join(" | ")
+
+              csv << [
+                gem[:name], gem[:version], gem[:source], gem[:secure],
+                advisories, cves, urls, patched
+              ]
+            end
+          end
+        else
+          raise "Unsupported format"
+        end
+
+      File.write(file_path, output_data)
+      file_path
     end
   end
 


### PR DESCRIPTION
## What
Adding CSV support for exporting `Gemfile.lock` analysis.

## Why
For teams or people who want to look at their dependencies in sheets or excel for further data analytics.

## Where
Mainly in `parser.rb` and `analyze.rb` for the major changes as well as associated test in the `/test` directory