### PR TITLE
[JAR-16] adding the ability to parse for dev dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,27 @@
+name: Release Gem
+
+on:
+  workflow_dispatch:
+
+jobs:
+  release:
+    name: Publish to RubyGems
+    runs-on: ubuntu-latest
+    environment: release-approval
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.4.2'
+          bundler-cache: true
+
+      - name: Build gem
+        run: gem build orion.gemspec
+
+      - name: Publish to RubyGems
+        run: gem push orion-*.gem
+        env:
+          RUBYGEMS_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}

--- a/lib/orion/version.rb
+++ b/lib/orion/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Orion
-  VERSION = "0.5.1"
+  VERSION = "0.6.1"
 end


### PR DESCRIPTION
## What
Adding the ability to parse development dependencies.

## Why
To give users more control over which dependencies they are viewing as well as their vulnerabilities.

## Where
Mainly in the main `parser` class as well as `security` class. Associated test are placed in `/test` dir.